### PR TITLE
[PIC-158] Incremental/Rolling Authz Support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@picketapi/picket-react",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@picketapi/picket-react",
-      "version": "0.0.53",
+      "version": "0.0.54",
       "license": "ISC",
       "dependencies": {
-        "@picketapi/picket-js": "^0.0.72",
+        "@picketapi/picket-js": "^0.0.73",
         "@types/react": "^17.0.39",
         "@types/react-dom": "^17.0.0",
         "react": "17.0.2",
@@ -4493,9 +4493,9 @@
       "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "node_modules/@picketapi/picket-js": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/@picketapi/picket-js/-/picket-js-0.0.72.tgz",
-      "integrity": "sha512-z7WCYn50Nnm4fuTC5smqkO7lDas36K5G3gOIGxno3xNljEC0ph/gzcs6iwmZm0c2WH71OtVuFK6a/2UjFa/RWg==",
+      "version": "0.0.73",
+      "resolved": "https://registry.npmjs.org/@picketapi/picket-js/-/picket-js-0.0.73.tgz",
+      "integrity": "sha512-geV9MvUcKPnl3SH+UD3Dn7jQI48Vex9vCGKwFMzuSbw2sazZG/uhYDvpWpdFG/amK+TYTrNjyltHzGoxK4pgKg==",
       "dependencies": {
         "@coinbase/wallet-sdk": "^3.4.1",
         "@solana/wallet-adapter-base": "^0.9.5",
@@ -4507,6 +4507,7 @@
         "@wagmi/core": "^0.5.4",
         "@walletconnect/ethereum-provider": "^1.8.0",
         "@walletconnect/web3-provider": "^1.8.0",
+        "bignumber.js": "^9.1.0",
         "bs58": "^4.0.1",
         "ethers": "^5.5.1",
         "pkce-challenge": "^3.0.0",
@@ -7306,9 +7307,9 @@
       }
     },
     "node_modules/bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A==",
       "engines": {
         "node": "*"
       }
@@ -20433,9 +20434,9 @@
       "integrity": "sha512-HaW78NszGzRZd9SeoI3JD11JqY+lubnaOx7Pewj5pfjqWXOEATpeKIFb9Z4t2WBUK2iryiXX3lzWwmYWgUL0Ug=="
     },
     "@picketapi/picket-js": {
-      "version": "0.0.72",
-      "resolved": "https://registry.npmjs.org/@picketapi/picket-js/-/picket-js-0.0.72.tgz",
-      "integrity": "sha512-z7WCYn50Nnm4fuTC5smqkO7lDas36K5G3gOIGxno3xNljEC0ph/gzcs6iwmZm0c2WH71OtVuFK6a/2UjFa/RWg==",
+      "version": "0.0.73",
+      "resolved": "https://registry.npmjs.org/@picketapi/picket-js/-/picket-js-0.0.73.tgz",
+      "integrity": "sha512-geV9MvUcKPnl3SH+UD3Dn7jQI48Vex9vCGKwFMzuSbw2sazZG/uhYDvpWpdFG/amK+TYTrNjyltHzGoxK4pgKg==",
       "requires": {
         "@coinbase/wallet-sdk": "^3.4.1",
         "@solana/wallet-adapter-base": "^0.9.5",
@@ -20447,6 +20448,7 @@
         "@wagmi/core": "^0.5.4",
         "@walletconnect/ethereum-provider": "^1.8.0",
         "@walletconnect/web3-provider": "^1.8.0",
+        "bignumber.js": "^9.1.0",
         "bs58": "^4.0.1",
         "ethers": "^5.5.1",
         "pkce-challenge": "^3.0.0",
@@ -22741,9 +22743,9 @@
       }
     },
     "bignumber.js": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.0.2.tgz",
-      "integrity": "sha512-GAcQvbpsM0pUb0zw1EI0KhQEZ+lRwR5fYaAp3vPOYuP7aDvGy6cVN6XHLauvF8SOga2y0dcLcjt3iQDTSEliyw=="
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
+      "integrity": "sha512-4LwHK4nfDOraBCtst+wOWIHbu1vhvAPJK8g8nROd4iuc3PSEjWif/qwbkh8jwCJz6yDBvtU4KPynETgrfh7y3A=="
     },
     "bind-decorator": {
       "version": "1.0.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picketapi/picket-react",
-  "version": "0.0.53",
+  "version": "0.0.54",
   "description": "React SDK for the picket-js client",
   "main": "dist/index.js",
   "source": "src/index.ts",
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/picketapi/picket-react#readme",
   "dependencies": {
-    "@picketapi/picket-js": "^0.0.72",
+    "@picketapi/picket-js": "^0.0.73",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.0",
     "react": "17.0.2",

--- a/src/PicketProvider.tsx
+++ b/src/PicketProvider.tsx
@@ -209,18 +209,24 @@ export const PicketProvider = ({
 
   const isAuthorized: typeof picket.isCurrentUserAuthorized = useCallback(
     async ({ requirements, revalidate = false }) => {
-      setIsAuthorizing(true);
-      const allowed = await picket.isCurrentUserAuthorized({
-        requirements,
-        revalidate,
-      });
+      try {
+        setIsAuthorizing(true);
+        const allowed = await picket.isCurrentUserAuthorized({
+          requirements,
+          revalidate,
+        });
 
-      // refresh local auth state
-      const auth = await picket.authState();
-      setAuthState(auth || undefined);
+        // refresh local auth state
+        const auth = await picket.authState();
+        setAuthState(auth || undefined);
 
-      setIsAuthorizing(false);
-      return allowed;
+        setIsAuthorizing(false);
+        return allowed;
+      } catch (err) {
+        console.error(err);
+        // should never happen but to be safe
+        return false;
+      }
     },
     [picket]
   );
@@ -229,10 +235,17 @@ export const PicketProvider = ({
     (requirements: AuthRequirements) => {
       if (!authState) return false;
       const { user } = authState;
-      return Picket.meetsAuthRequirements({
-        user,
-        requirements,
-      });
+
+      try {
+        return Picket.meetsAuthRequirements({
+          user,
+          requirements,
+        });
+      } catch (err) {
+        console.error(err);
+        // should never happen but to be safe
+        return false;
+      }
     },
     [authState]
   );

--- a/src/PicketProvider.tsx
+++ b/src/PicketProvider.tsx
@@ -220,12 +220,13 @@ export const PicketProvider = ({
         const auth = await picket.authState();
         setAuthState(auth || undefined);
 
-        setIsAuthorizing(false);
         return allowed;
       } catch (err) {
         console.error(err);
         // should never happen but to be safe
         return false;
+      } finally {
+        setIsAuthorizing(false);
       }
     },
     [picket]

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ import Picket, {
   LoginRequest,
   LoginOptions,
   ErrorResponse,
+  AuthRequirements,
 } from "@picketapi/picket-js";
 
 type IPicket = InstanceType<typeof Picket>;
@@ -31,12 +32,27 @@ export interface IPicketContext {
   nonce: IPicket["nonce"];
   authState?: AuthState;
   error?: Error | ErrorResponse;
+
+  // consider making this requirements specific
+  // Record<string, boolean>
+  isAuthorizing: boolean;
+  // isAuthorized is a wrapper around isCurrentUserAuthorized
+  isAuthorized: ({
+    requirements,
+    revalidate,
+  }: {
+    requirements: AuthRequirements;
+    revalidate?: boolean;
+  }) => Promise<boolean>;
+  // isAlreadyAuthorized is a synchronous, local only version of isAuthorized
+  isAlreadyAuthorized: (requirements: AuthRequirements) => boolean;
 }
 
 // @ts-ignore Ignore missing picket key, so we don't have to initialize here
 const initialContext: IPicketContext = {
   isAuthenticating: true,
   isAuthenticated: false,
+  isAuthorizing: false,
 };
 
 export const PicketContext = createContext(initialContext);


### PR DESCRIPTION
### Description

Allow users to incrementally authorize users for different requirements. This enables apps that partition their app by different tokens (i.e token-based communities) to let a user login via Picket then progressively authorize to get access to different token-gated pages. Once a user is authorized, it will be cached in their JWT for fast future checks.
