### PR TITLE
[PIC-178] Expose auth Method to Allow for Custom Frontends

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@picketapi/picket-react",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@picketapi/picket-react",
-      "version": "0.0.59",
+      "version": "0.0.60",
       "license": "ISC",
       "dependencies": {
         "@picketapi/picket-js": "^0.0.77",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@picketapi/picket-react",
-  "version": "0.0.59",
+  "version": "0.0.60",
   "description": "React SDK for the picket-js client",
   "main": "dist/index.js",
   "source": "src/index.ts",

--- a/src/context.ts
+++ b/src/context.ts
@@ -6,6 +6,7 @@ import Picket, {
   LoginRequest,
   LoginOptions,
   ErrorResponse,
+  AuthRequest,
   AuthRequirements,
 } from "@picketapi/picket-js";
 
@@ -30,6 +31,7 @@ export interface IPicketContext {
   logout: IPicket["logout"];
   connect: IPicket["connect"];
   nonce: IPicket["nonce"];
+  auth: (args: AuthRequest) => Promise<AuthState | undefined>;
   authState?: AuthState;
   error?: Error | ErrorResponse;
 


### PR DESCRIPTION
### Description

Exposes a wrapped version of `picket.auth` to allow users to more easily build their own custom frontends or plug into existing ones like RainbowKit